### PR TITLE
Support enableDecimalLogicalType compiler flag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Built using Avro 1.8.2
 * Breaking backward compatibility with Avro versions older than 1.8.2
 * Add new configuration option "enableDecimalLogicalType" to generate `BigDecimal` for fields annotated with `logicalType` equals to `decimal`
+* Breaking backward compatibility caused by "enableDecimalLogicalType" default value set `true`. `BigDecimal` will be used instead of old usage of `ByteBuffer`
 
 ## 0.10.0
 * Drop support for Gradle 2.x

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 ## Unreleased
 * Built using Gradle 4.2.1
 * Began testing using Java 9
+* Built using Avro 1.8.2
+* Breaking backward compatibility with Avro versions older than 1.8.2
+* Add new configuration option "enableDecimalLogicalType" to generate `BigDecimal` for fields annotated with `logicalType` equals to `decimal`
 
 ## 0.10.0
 * Drop support for Gradle 2.x

--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ Actually, it will attempt to process an "avro" directory in every `SourceSet` (m
 
 There are a number of configuration options supported in the `avro` block.
 
-| option                  | default               | description                                       |
-| ----------------------- | --------------------- | ------------------------------------------------- |
-| createSetters           | `true`                | `createSetters` passed to Avro compiler           |
-| fieldVisibility         | `"PUBLIC_DEPRECATED"` | `fieldVisibility` passed to Avro compiler         |
-| outputCharacterEncoding | see below             | `outputCharacterEncoding` passed to Avro compiler |
-| stringType              | `"String"`            | `stringType` passed to Avro compiler              |
-| templateDirectory       | see below             | `templateDir` passed to Avro compiler             |
+| option                    | default               | description                                           |
+| --------------------------| --------------------- | -------------------------------------------------     |
+| createSetters             | `true`                | `createSetters` passed to Avro compiler               |
+| fieldVisibility           | `"PUBLIC_DEPRECATED"` | `fieldVisibility` passed to Avro compiler             |
+| outputCharacterEncoding   | see below             | `outputCharacterEncoding` passed to Avro compiler     |
+| stringType                | `"String"`            | `stringType` passed to Avro compiler                  |
+| templateDirectory         | see below             | `templateDir` passed to Avro compiler                 |
+| enableDecimalLogicalType  | `true`                | `enableDecimalLogicalType` passed to Avro compiler    |
 
 ## createSetters
 
@@ -130,6 +131,22 @@ If desired, you can override the template set used by either setting this proper
 ```groovy
 avro {
     templateDirectory = "/path/to/velocity/templates"
+}
+```
+
+## enableDecimalLogicalType
+
+Valid values: `true` (default), `false`; supports equivalent `String` values
+
+By default, generated Java files will use [`java.math.BigDecimal`](https://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html) 
+for representing `fixed` or `bytes` fields annotated with `"logicalType": "decimal"`.
+Set to `false` to use [`java.nio.ByteBuffer`](https://docs.oracle.com/javase/7/docs/api/java/nio/ByteBuffer.html) in generated classes.
+
+Example:
+
+```groovy
+avro {
+    enableDecimalLogicalType = false
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
     jcenter()
 }
 
-def compileAvroVersion = "1.8.1"
+def compileAvroVersion = "1.8.2"
 
 dependencies {
     compile localGroovy()
@@ -168,7 +168,7 @@ test {
     ]
 }
 
-def avroVersions = ["1.8.0", "1.8.1"]
+def avroVersions = ["1.8.2"]
 def gradleVersions = ["3.0", "3.1", "3.2", "3.2.1", "3.3", "3.4", "3.4.1", "3.5", "3.5.1", "4.0", "4.0.1", "4.0.2", "4.1", "4.2", "4.2.1"]
 
 avroVersions.each { def avroVersion ->

--- a/src/main/java/com/commercehub/gradle/plugin/avro/AvroBasePlugin.java
+++ b/src/main/java/com/commercehub/gradle/plugin/avro/AvroBasePlugin.java
@@ -52,6 +52,12 @@ public class AvroBasePlugin implements Plugin<Project> {
                 return DEFAULT_CREATE_SETTERS;
             }
         });
+        extensionMapping.map(OPTION_ENABLE_DECIMAL_LOGICAL_TYPE, new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return DEFAULT_ENABLE_DECIMAL_LOGICAL_TYPE;
+            }
+        });
         project.getTasks().withType(GenerateAvroJavaTask.class).all(new Action<GenerateAvroJavaTask>() {
             @Override
             public void execute(GenerateAvroJavaTask task) {
@@ -84,6 +90,12 @@ public class AvroBasePlugin implements Plugin<Project> {
                     @Override
                     public Boolean call() throws Exception {
                         return avroExtension.isCreateSetters();
+                    }
+                });
+                taskMapping.map(OPTION_ENABLE_DECIMAL_LOGICAL_TYPE, new Callable<Boolean>() {
+                    @Override
+                    public Boolean call() throws Exception {
+                        return avroExtension.isEnableDecimalLogicalType();
                     }
                 });
             }

--- a/src/main/java/com/commercehub/gradle/plugin/avro/AvroExtension.java
+++ b/src/main/java/com/commercehub/gradle/plugin/avro/AvroExtension.java
@@ -21,4 +21,5 @@ public interface AvroExtension {
     String getFieldVisibility();
     String getTemplateDirectory();
     boolean isCreateSetters();
+    boolean isEnableDecimalLogicalType();
 }

--- a/src/main/java/com/commercehub/gradle/plugin/avro/Constants.java
+++ b/src/main/java/com/commercehub/gradle/plugin/avro/Constants.java
@@ -31,6 +31,7 @@ class Constants {
     static final String DEFAULT_STRING_TYPE = StringType.String.name();
     static final String DEFAULT_FIELD_VISIBILITY = FieldVisibility.PUBLIC_DEPRECATED.name();
     static final boolean DEFAULT_CREATE_SETTERS = true;
+    static final boolean DEFAULT_ENABLE_DECIMAL_LOGICAL_TYPE = true;
 
     static final String SCHEMA_EXTENSION = "avsc";
     static final String PROTOCOL_EXTENSION = "avpr";
@@ -41,6 +42,7 @@ class Constants {
 
     static final String AVRO_EXTENSION_NAME = "avro";
 
+    static final String OPTION_ENABLE_DECIMAL_LOGICAL_TYPE = "enableDecimalLogicalType";
     static final String OPTION_CREATE_SETTERS = "createSetters";
     static final String OPTION_TEMPLATE_DIRECTORY = "templateDirectory";
     static final String OPTION_FIELD_VISIBILITY = "fieldVisibility";

--- a/src/main/java/com/commercehub/gradle/plugin/avro/DefaultAvroExtension.java
+++ b/src/main/java/com/commercehub/gradle/plugin/avro/DefaultAvroExtension.java
@@ -26,6 +26,7 @@ public class DefaultAvroExtension implements AvroExtension {
     private String fieldVisibility;
     private String templateDirectory;
     private boolean createSetters;
+    private boolean enableDecimalLogicalType;
 
     @Override
     public String getOutputCharacterEncoding() {
@@ -82,5 +83,14 @@ public class DefaultAvroExtension implements AvroExtension {
 
     public void setCreateSetters(String createSetters) {
         this.createSetters = Boolean.parseBoolean(createSetters);
+    }
+
+    @Override
+    public boolean isEnableDecimalLogicalType() {
+        return enableDecimalLogicalType;
+    }
+
+    public void setEnableDecimalLogicalType(String enableDecimalLogicalType) {
+        this.enableDecimalLogicalType = Boolean.parseBoolean(enableDecimalLogicalType);
     }
 }

--- a/src/main/java/com/commercehub/gradle/plugin/avro/GenerateAvroJavaTask.java
+++ b/src/main/java/com/commercehub/gradle/plugin/avro/GenerateAvroJavaTask.java
@@ -54,6 +54,7 @@ public class GenerateAvroJavaTask extends OutputDirTask {
     private String fieldVisibility = DEFAULT_FIELD_VISIBILITY;
     private String templateDirectory;
     private boolean createSetters = DEFAULT_CREATE_SETTERS;
+    private boolean enableDecimalLogicalType = DEFAULT_ENABLE_DECIMAL_LOGICAL_TYPE;
 
     private transient StringType parsedStringType;
     private transient FieldVisibility parsedFieldVisibility;
@@ -117,6 +118,15 @@ public class GenerateAvroJavaTask extends OutputDirTask {
         this.createSetters = Boolean.parseBoolean(createSetters);
     }
 
+    @Input
+    public boolean isEnableDecimalLogicalType() {
+        return enableDecimalLogicalType;
+    }
+
+    public void setEnableDecimalLogicalType(String enableDecimalLogicalType) {
+        this.enableDecimalLogicalType = Boolean.parseBoolean(enableDecimalLogicalType);
+    }
+
     @TaskAction
     protected void process() {
         parsedStringType = Enums.parseCaseInsensitive(OPTION_STRING_TYPE, StringType.values(), getStringType());
@@ -127,6 +137,7 @@ public class GenerateAvroJavaTask extends OutputDirTask {
         getLogger().debug("Using fieldVisibility {}", parsedFieldVisibility.name());
         getLogger().debug("Using templateDirectory '{}'", getTemplateDirectory());
         getLogger().debug("Using createSetters {}", isCreateSetters());
+        getLogger().debug("Using enableDecimalLogicalType {}", isEnableDecimalLogicalType());
         getLogger().info("Found {} files", getInputs().getSourceFiles().getFiles().size());
         failOnUnsupportedFiles();
         preClean();
@@ -255,6 +266,8 @@ public class GenerateAvroJavaTask extends OutputDirTask {
             compiler.setTemplateDir(templateDirectory);
         }
         compiler.setCreateSetters(isCreateSetters());
+        compiler.setEnableDecimalLogicalType(isEnableDecimalLogicalType());
+
         compiler.compileToDestination(sourceFile, getOutputDir());
     }
 }

--- a/src/test/groovy/com/commercehub/gradle/plugin/avro/AvroPluginFunctionalSpec.groovy
+++ b/src/test/groovy/com/commercehub/gradle/plugin/avro/AvroPluginFunctionalSpec.groovy
@@ -118,14 +118,14 @@ class AvroPluginFunctionalSpec extends FunctionalSpec {
     def "gives a meaningful error message when presented a malformed schema file"() {
         given:
         copyResource("enumMalformed.avsc", avroDir)
-
+        def errorFilePath = new File("src/main/avro/enumMalformed.avsc").path
         when:
         def result = runAndFail()
 
         then:
         taskInfoAbsent || result.task(":generateAvroJava").outcome == FAILED
         result.output.contains("> Could not compile schema definition files:")
-        result.output.contains("* src/main/avro/enumMalformed.avsc: \"enum\" is not a defined name. The type of the \"gender\" " +
+        result.output.contains("* $errorFilePath: \"enum\" is not a defined name. The type of the \"gender\" " +
                 "field must be a defined name or a {\"type\": ...} expression.")
     }
 }

--- a/src/test/groovy/com/commercehub/gradle/plugin/avro/DuplicateHandlingFunctionalSpec.groovy
+++ b/src/test/groovy/com/commercehub/gradle/plugin/avro/DuplicateHandlingFunctionalSpec.groovy
@@ -58,6 +58,8 @@ class DuplicateHandlingFunctionalSpec extends FunctionalSpec {
     def "Duplicate enum definition fails if definition differs"() {
         given:
         copyDifferentEnum()
+        def errorFilePath1 = new File("src/main/avro/duplicate/Dog.avsc").path
+        def errorFilePath2 = new File("src/main/avro/duplicate/Person.avsc").path
 
         when:
         def result = runAndFail()
@@ -65,20 +67,21 @@ class DuplicateHandlingFunctionalSpec extends FunctionalSpec {
         then:
         taskInfoAbsent || result.task(":generateAvroJava").outcome == FAILED
         result.output.contains("Found conflicting definition of type example.Gender in "
-            + "[src/main/avro/duplicate/Dog.avsc, src/main/avro/duplicate/Person.avsc]")
+            + "[$errorFilePath1, $errorFilePath2]")
     }
 
     def "Duplicate record definition fails if definition differs"() {
         given:
         copyDifferentRecord()
-
+        def errorFilePath1 = new File("src/main/avro/duplicate/Person.avsc").path
+        def errorFilePath2 = new File("src/main/avro/duplicate/Spider.avsc").path
         when:
         def result = runAndFail()
 
         then:
         taskInfoAbsent || result.task(":generateAvroJava").outcome == FAILED
         result.output.contains("Found conflicting definition of type example.Person in "
-            + "[src/main/avro/duplicate/Person.avsc, src/main/avro/duplicate/Spider.avsc]")
+            + "[$errorFilePath1, $errorFilePath2]")
     }
 
     private void copyIdenticalEnum() {

--- a/src/test/groovy/com/commercehub/gradle/plugin/avro/OptionsFunctionalSpec.groovy
+++ b/src/test/groovy/com/commercehub/gradle/plugin/avro/OptionsFunctionalSpec.groovy
@@ -19,6 +19,8 @@ import org.apache.avro.compiler.specific.SpecificCompiler.FieldVisibility
 import org.apache.avro.generic.GenericData.StringType
 import spock.lang.Unroll
 
+import java.nio.ByteBuffer
+
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
@@ -220,15 +222,15 @@ class OptionsFunctionalSpec extends FunctionalSpec {
         def content = projectFile("build/generated-main-avro-java/example/avro/User.java").text
 
         and: "the specified enableDecimalLogicalType is used"
-        content.contains("public void setSalary(${BigDecimal.name} value)") == expectedPresent
+        content.contains("public void setSalary(${fieldClz.name} value)")
 
         where:
-        enableDecimalLogicalType | expectedPresent
-        "Boolean.TRUE"           | true
-        "Boolean.FALSE"          | false
-        "true"                   | true
-        "false"                  | false
-        "'true'"                 | true
-        "'false'"                | false
+        enableDecimalLogicalType | fieldClz
+        "Boolean.TRUE"           | BigDecimal
+        "Boolean.FALSE"          | ByteBuffer
+        "true"                   | BigDecimal
+        "false"                  | ByteBuffer
+        "'true'"                 | BigDecimal
+        "'false'"                | ByteBuffer
     }
 }

--- a/src/test/resources/com/commercehub/gradle/plugin/avro/user.avsc
+++ b/src/test/resources/com/commercehub/gradle/plugin/avro/user.avsc
@@ -4,6 +4,10 @@
  "fields": [
      {"name": "name", "type": "string"},
      {"name": "favorite_number",  "type": ["int", "null"]},
-     {"name": "favorite_color", "type": ["string", "null"]}
+     {"name": "favorite_color", "type": ["string", "null"]},
+     {
+         "name": "salary",
+         "type": { "type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2 }
+     }
  ]
 }


### PR DESCRIPTION
- Fixing functional tests on Windows
- Built with Avro 1.8.2
- Breaking compatibility changes, only compatible with Avro >=1.8.2
- Updated release information and README
- Added `enableDecimalLogicalType` plugin option and proces it by Avro complier
- Functional tests for `enableDecimalLogicalType`

Resolves #34 