### PR TITLE
Adding sample project to demonstrate lack of cache

### DIFF
--- a/avro-cache-test/.gitignore
+++ b/avro-cache-test/.gitignore
@@ -1,0 +1,77 @@
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+
+# OS generated files #
+######################
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db
+
+# Editor Files #
+################
+*~
+*.swp
+
+# Gradle Files #
+################
+.gradle
+local.properties
+
+# Build output directies
+/target
+**/test-output
+**/target
+**/bin
+build
+*/build
+**/build
+.m2
+
+# IntelliJ specific files/directories
+out
+.idea
+*.ipr
+*.iws
+*.iml
+atlassian-ide-plugin.xml
+
+# Eclipse specific files/directories
+.classpath
+.project
+.settings
+.metadata
+.factorypath
+.generated
+
+# NetBeans specific files/directories
+.nbattrs
+
+# Specifically include the gradle wrapper jar
+!/gradle/wrapper/gradle-wrapper.jar
+
+# Scripts for use on the local machine
+/local-*.sh

--- a/avro-cache-test/.gitignore
+++ b/avro-cache-test/.gitignore
@@ -40,6 +40,7 @@ Thumbs.db
 ################
 .gradle
 local.properties
+reports
 
 # Build output directies
 /target

--- a/avro-cache-test/build.gradle
+++ b/avro-cache-test/build.gradle
@@ -1,0 +1,20 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.14.1"
+    }
+}
+
+subprojects {
+
+    apply plugin: "com.commercehub.gradle.plugin.avro"
+
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        compile "org.apache.avro:avro:1.8.2"
+    }
+}

--- a/avro-cache-test/build.gradle
+++ b/avro-cache-test/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
     repositories {
         jcenter()
+        mavenLocal()
     }
     dependencies {
-        classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.14.1"
+        classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.14.2-SNAPSHOT"
     }
 }
 

--- a/avro-cache-test/module-1/src/main/avro/interop.avdl
+++ b/avro-cache-test/module-1/src/main/avro/interop.avdl
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Currently genavro only does Protocols.
+@namespace("org.apache.avro")
+protocol InteropProtocol {
+  record Foo {
+    string label;
+  }
+
+  enum Kind { A, B, C }
+  fixed MD5(16);
+
+  record Node {
+    string label;
+    array<Node> children = [];
+  }
+
+  record Interop {
+    int intField = 1;
+    long longField = -1;
+    string stringField;
+    boolean boolField = false;
+    float floatField = 0.0;
+    double doubleField = -1.0e12;
+    null nullField;
+    array<double> arrayField = [];
+    map<Foo> mapField;
+    union { boolean, double, array<bytes> } unionFIeld;
+    Kind enumField;
+    MD5 fixedField;
+    Node recordField;
+  }
+
+}

--- a/avro-cache-test/module-1/src/main/avro/user.avsc
+++ b/avro-cache-test/module-1/src/main/avro/user.avsc
@@ -1,0 +1,13 @@
+{"namespace": "example.avro",
+ "type": "record",
+ "name": "User",
+ "fields": [
+     {"name": "name", "type": "string"},
+     {"name": "favorite_number",  "type": ["int", "null"]},
+     {"name": "favorite_color", "type": ["string", "null"]},
+     {
+         "name": "salary",
+         "type": { "type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2 }
+     }
+ ]
+}

--- a/avro-cache-test/module-2/src/main/avro/interop.avdl
+++ b/avro-cache-test/module-2/src/main/avro/interop.avdl
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Currently genavro only does Protocols.
+@namespace("org.apache.avro")
+protocol InteropProtocol {
+  record Foo {
+    string label;
+  }
+
+  enum Kind { A, B, C }
+  fixed MD5(16);
+
+  record Node {
+    string label;
+    array<Node> children = [];
+  }
+
+  record Interop {
+    int intField = 1;
+    long longField = -1;
+    string stringField;
+    boolean boolField = false;
+    float floatField = 0.0;
+    double doubleField = -1.0e12;
+    null nullField;
+    array<double> arrayField = [];
+    map<Foo> mapField;
+    union { boolean, double, array<bytes> } unionFIeld;
+    Kind enumField;
+    MD5 fixedField;
+    Node recordField;
+  }
+
+}

--- a/avro-cache-test/module-2/src/main/avro/user.avsc
+++ b/avro-cache-test/module-2/src/main/avro/user.avsc
@@ -1,0 +1,13 @@
+{"namespace": "example.avro",
+ "type": "record",
+ "name": "User",
+ "fields": [
+     {"name": "name", "type": "string"},
+     {"name": "favorite_number",  "type": ["int", "null"]},
+     {"name": "favorite_color", "type": ["string", "null"]},
+     {
+         "name": "salary",
+         "type": { "type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2 }
+     }
+ ]
+}

--- a/avro-cache-test/settings.gradle
+++ b/avro-cache-test/settings.gradle
@@ -1,0 +1,1 @@
+include 'module-1', 'module-2'


### PR DESCRIPTION
fix #48 (or at least provides an example for it)

As discussed, here is a quick example where the avro plugin is not supporting the gradle cache. The user.acsv is from the tests and duplicated in 2 submodules.

When running
`gradlew clean assemble --profile --build-cache` from the _avro-cache-test_ project and opening the profile, you will see under task execution :

> 

Task | Duration | Result
-- | -- | --
:module-1 | 0.276s | (total)
:module-1:compileJava | 0.250s |  
:module-1:generateAvroJava | 0.015s |  
:module-1:jar | 0.005s |  
:module-1:clean | 0.004s |  
:module-1:assemble | 0.001s | Did No Work
:module-1:generateAvroProtocol | 0.001s | NO-SOURCE
:module-1:classes | 0s | Did No Work
:module-1:processResources | 0s | NO-SOURCE
:module-2 | 0.049s | (total)
:module-2:compileJava | 0.025s | FROM-CACHE
:module-2:generateAvroJava | 0.013s |  
:module-2:jar | 0.007s |  
:module-2:clean | 0.003s |  
:module-2:processResources | 0.001s | NO-SOURCE
:module-2:assemble | 0s | Did No Work
:module-2:classes | 0s | UP-TO-DATE
:module-2:generateAvroProtocol | 0s | NO-SOURCE
: | 0s | (total)

generateAvroJava is re-run in the second project (module-2) even though it's the exact same avro file.
compileJava is handling the cache correctly and is not recompiling in the 2nd module since the content is exactly the same as the first module.

This example is obviously not a "real life" example, but it showcase the behaviour.

